### PR TITLE
Update lodash and dev dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -98,3 +98,8 @@
 ## 1.4.5
 
 * Disable Travis dependency cache
+
+## 1.4.6
+
+* Update lodash dependency
+* Update dev dependencies

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "url": "https://github.com/overlookmotel/require-folder-tree/issues"
   },
   "dependencies": {
-    "lodash": "3.8.0"
+    "lodash": "^4.17.10"
   },
   "devDependencies": {
-    "mocha": "^2.2.4",
-    "chai": "^2.3.0",
-	"jshint": "^2.7.0",
-    "istanbul": "^0.3.14",
-    "coveralls": "^2.11.2"
+    "mocha": "^5.1.1",
+    "chai": "^4.1.2",
+    "jshint": "^2.9.5",
+    "istanbul": "^0.4.5",
+    "coveralls": "^3.0.1"
   },
   "keywords": [
     "require",


### PR DESCRIPTION
Version 3 of the Lodash module contains a security vulnerability. That
vulnerability was patched in the 4.17.5 release.

Note that version 4 of Lodash removes support for Internet Explorer 6,
7, and 8. The require-folder-tree project does not formally document
compatibility with web browsers, but the source is currently dependent
on Array prototype methods introduced in ES5. This means that updating
Lodash does not effect the set of browsers supported by this project.

[1] https://hackerone.com/reports/310443
[2] https://github.com/lodash/lodash/wiki/Changelog#v400